### PR TITLE
Update installation/usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,57 @@
 # sqlfmt
 
-- `go get github.com/jackc/sqlfmt`
-- `echo "select * from users" | sqlfmt`
+## Installation
+
+```sh
+$ go get github.com/jackc/sqlfmt/...
+$ which sqlfmt
+$GOPATH/bin/sqlfmt
+```
+
+## Usage
+
+  - You can either:
+
+    + Provide the path to one or more SQL files as command line arguments:
+
+      ```sh
+      $ sqlfmt testdata/select_where.input.sql
+      select
+        foo,
+        bar
+      from
+        baz
+      where
+        foo > 5
+        and bar < 2
+      ```
+
+    + Or, directly provide the SQL string via stdin:
+
+      ```sh
+      $ echo "select * from users" | sqlfmt
+      select
+        *
+      from
+        users
+      ```
+
+      ```sh
+      $ sqlfmt < testdata/like.input.sql
+      select
+        foo,
+        bar
+      from
+        baz
+      where
+        foo like 'abd%'
+        or foo like 'ada%' escape '!'
+        or foo not like 'abd%'
+        or foo not like 'ada%' escape '!'
+        or foo ilike 'efg%'
+        or foo ilike 'ada%' escape '!'
+        or foo not ilike 'efg%'
+        or foo not ilike 'ada%' escape '!'
+      ```
+
+  - View [testdata](./testdata) for more examples.


### PR DESCRIPTION
Fixes path used with `go get` (the `/...` is required to install the package to `$GOPATH/bin`).

Adds a file path (command line arg.) example with [`testdata/select_where.input.sql`](https://github.com/jackc/sqlfmt/blob/master/testdata/select_where.input.sql) and a redirection example with [`testdata/like.input.sql`](https://github.com/jackc/sqlfmt/blob/master/testdata/like.input.sql).