### PR TITLE
refactor(filepath): Use path/filepath pkg

### DIFF
--- a/cmd/sqlfmt/main.go
+++ b/cmd/sqlfmt/main.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
 	"path/filepath"
 
 	"github.com/jackc/sqlfmt"
@@ -57,7 +56,7 @@ func (j *job) run() error {
 	if j.w == nil {
 		dir := filepath.Dir(j.name)
 		base := filepath.Base(j.name)
-		tmpPath = path.Join(dir, "."+base+".sqlfmt")
+		tmpPath = filepath.Join(dir, "."+base+".sqlfmt")
 		j.w, err = os.Create(tmpPath)
 		if err != nil {
 			return err

--- a/cmd/sqlfmt/sqlfmt_test.go
+++ b/cmd/sqlfmt/sqlfmt_test.go
@@ -6,7 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 )
@@ -78,19 +78,19 @@ func TestFileInput(t *testing.T) {
 	inputFile := "simple_select_without_from.input.sql"
 	expectedOutputFile := "simple_select_without_from.golden.sql"
 
-	expected, err := ioutil.ReadFile(path.Join("../../testdata", expectedOutputFile))
+	expected, err := ioutil.ReadFile(filepath.Join("../../testdata", expectedOutputFile))
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	filePath := path.Join("../../testdata", inputFile)
+	filePath := filepath.Join("../../testdata", inputFile)
 	output, err := sqlfmt(nil, filePath)
 	if err != nil {
 		t.Fatalf("sqlfmt failed with %s: %v", filePath, err)
 	}
 
 	if bytes.Compare(output, expected) != 0 {
-		actualFileName := path.Join("tmp", "TestFileInput.sql")
+		actualFileName := filepath.Join("tmp", "TestFileInput.sql")
 		err = ioutil.WriteFile(actualFileName, output, os.ModePerm)
 		if err != nil {
 			t.Fatal(err)
@@ -103,20 +103,20 @@ func TestFileInput(t *testing.T) {
 func TestFileFormatInPlace(t *testing.T) {
 	inputFile := "simple_select_without_from.input.sql"
 	expectedOutputFile := "simple_select_without_from.golden.sql"
-	expectedOutputPath := path.Join("../../testdata", expectedOutputFile)
+	expectedOutputPath := filepath.Join("../../testdata", expectedOutputFile)
 
 	expected, err := ioutil.ReadFile(expectedOutputPath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	sourcePath := path.Join("../../testdata", inputFile)
+	sourcePath := filepath.Join("../../testdata", inputFile)
 	source, err := ioutil.ReadFile(sourcePath)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	tmpFilePath := path.Join("tmp", inputFile)
+	tmpFilePath := filepath.Join("tmp", inputFile)
 	err = ioutil.WriteFile(tmpFilePath, source, os.ModePerm)
 	if err != nil {
 		t.Fatal(err)
@@ -155,19 +155,19 @@ func TestMultipleFileFormatInPlace(t *testing.T) {
 	var err error
 	args := []string{"-w"}
 	for i, _ := range tests {
-		sourcePath := path.Join("../../testdata", tests[i].Name+".input.sql")
+		sourcePath := filepath.Join("../../testdata", tests[i].Name+".input.sql")
 		tests[i].Source, err = ioutil.ReadFile(sourcePath)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		expectedOutputPath := path.Join("../../testdata", tests[i].Name+".golden.sql")
+		expectedOutputPath := filepath.Join("../../testdata", tests[i].Name+".golden.sql")
 		tests[i].Expected, err = ioutil.ReadFile(expectedOutputPath)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		tests[i].TmpFilePath = path.Join("tmp", tests[i].Name+".sql")
+		tests[i].TmpFilePath = filepath.Join("tmp", tests[i].Name+".sql")
 		err = ioutil.WriteFile(tests[i].TmpFilePath, tests[i].Source, os.ModePerm)
 		if err != nil {
 			t.Fatal(err)
@@ -209,8 +209,8 @@ func TestSqlFmtAll(t *testing.T) {
 		}
 
 		testName := fi.Name()[:len(fi.Name())-10]
-		inputPath := path.Join("../../testdata", fi.Name())
-		goldenPath := path.Join("../../testdata", testName+".golden.sql")
+		inputPath := filepath.Join("../../testdata", fi.Name())
+		goldenPath := filepath.Join("../../testdata", testName+".golden.sql")
 
 		input, err := ioutil.ReadFile(inputPath)
 		if err != nil {
@@ -231,7 +231,7 @@ func TestSqlFmtAll(t *testing.T) {
 		}
 
 		if bytes.Compare(output, expected) != 0 {
-			actualFileName := path.Join("tmp", fmt.Sprintf("%s.sql", testName))
+			actualFileName := filepath.Join("tmp", fmt.Sprintf("%s.sql", testName))
 			err = ioutil.WriteFile(actualFileName, output, os.ModePerm)
 			if err != nil {
 				t.Fatal(err)

--- a/integration_test.go
+++ b/integration_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"testing"
 
 	"github.com/jackc/sqlfmt"
@@ -27,8 +27,8 @@ func TestIntegration(t *testing.T) {
 		}
 
 		testName := fi.Name()[:len(fi.Name())-10]
-		inputPath := path.Join("testdata", fi.Name())
-		goldenPath := path.Join("testdata", testName+".golden.sql")
+		inputPath := filepath.Join("testdata", fi.Name())
+		goldenPath := filepath.Join("testdata", testName+".golden.sql")
 
 		input, err := ioutil.ReadFile(inputPath)
 		if err != nil {
@@ -54,7 +54,7 @@ func TestIntegration(t *testing.T) {
 		stmt.RenderTo(r)
 
 		if outBuf.String() != string(expected) {
-			actualFileName := path.Join("tmp", fmt.Sprintf("%s.sql", testName))
+			actualFileName := filepath.Join("tmp", fmt.Sprintf("%s.sql", testName))
 			err = ioutil.WriteFile(actualFileName, outBuf.Bytes(), os.ModePerm)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
When manipulate operating system file paths, use `path/filepath`pkg instead of `path` pkg.

ref.
```
The path package should only be used for paths separated by forward slashes, such as the paths in URLs.
This package does not deal with Windows paths with drive letters or backslashes;
to manipulate operating system paths, use the path/filepath package.
```

https://golang.org/pkg/path/

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jackc/sqlfmt/8)
<!-- Reviewable:end -->
